### PR TITLE
Allow module item ordering

### DIFF
--- a/wasm-calc10/src/Calc/Build.hs
+++ b/wasm-calc10/src/Calc/Build.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 {-# OPTIONS -Wno-orphans #-}
 
@@ -11,27 +11,27 @@ module Calc.Build
   )
 where
 
-import           Calc.Ability.Check
-import           Calc.Dependencies
-import qualified Calc.Linearity                   as Linearity
-import           Calc.Module                      (resolveModule)
-import           Calc.Parser
-import           Calc.Parser.Types
-import           Calc.PrettyPrint                 (formatAndSave)
-import           Calc.Test
-import           Calc.Typecheck
-import           Calc.Wasm.FromExpr.Module
-import           Calc.Wasm.ToWasm.Module
-import           Calc.Wasm.WriteModule
-import           Control.Monad.IO.Class
-import           Data.Foldable                    (traverse_)
-import           Data.Monoid
-import           Data.Text                        (Text)
-import qualified Data.Text                        as T
-import qualified Error.Diagnose                   as Diag
-import           Error.Diagnose.Compat.Megaparsec
-import           System.Exit
-import           System.IO                        (hPutStrLn)
+import Calc.Ability.Check
+import Calc.Dependencies
+import qualified Calc.Linearity as Linearity
+import Calc.Module (resolveModule)
+import Calc.Parser
+import Calc.Parser.Types
+import Calc.PrettyPrint (formatAndSave)
+import Calc.Test
+import Calc.Typecheck
+import Calc.Wasm.FromExpr.Module
+import Calc.Wasm.ToWasm.Module
+import Calc.Wasm.WriteModule
+import Control.Monad.IO.Class
+import Data.Foldable (traverse_)
+import Data.Monoid
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Error.Diagnose as Diag
+import Error.Diagnose.Compat.Megaparsec
+import System.Exit
+import System.IO (hPutStrLn)
 
 build :: FilePath -> IO ()
 build filePath =
@@ -47,8 +47,9 @@ doBuild filePath = do
         >> pure (ExitFailure 1)
     Right parsedModuleItems ->
       case resolveModule parsedModuleItems of
-        Left err -> liftIO (print err) >>
-            pure (ExitFailure 1)
+        Left err ->
+          liftIO (print err)
+            >> pure (ExitFailure 1)
         Right parsedModule -> case elaborateModule parsedModule of
           Left typeErr -> do
             printDiagnostic (typeErrorDiagnostic (T.pack input) typeErr)

--- a/wasm-calc10/src/Calc/Module.hs
+++ b/wasm-calc10/src/Calc/Module.hs
@@ -1,37 +1,47 @@
-{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE FlexibleContexts #-}
+
 module Calc.Module (resolveModule) where
 
-import           Calc.Types.Memory
-import           Calc.Types.Module
-import           Control.Monad        (foldM)
-import           Control.Monad.Except
+import Calc.Types.Memory
+import Calc.Types.Module
+import Control.Monad (foldM)
+import Control.Monad.Except
 
 data ResolveModuleError ann = MultipleMemoryItems ann ann
-  deriving stock (Eq,Ord,Show, Functor)
+  deriving stock (Eq, Ord, Show, Functor)
 
 -- | turn lots of parts into a module
-resolveModule :: (MonadError (ResolveModuleError ann) m) =>
-  [ModuleItem ann] -> m (Module ann)
-resolveModule parts
-  = let emptyModule = Module {mdFunctions = mempty,mdImports = mempty,mdMemory = Nothing,
-            mdGlobals = mempty,mdTests = mempty}
-        withPart newModule item = case item of
-            ModuleFunction func -> pure $
-                newModule { mdFunctions = mdFunctions newModule <> [func] }
-            ModuleImport imp -> pure $
-                newModule { mdImports = mdImports newModule <> [imp] }
-            ModuleGlobal glob -> pure $
-                newModule { mdGlobals = mdGlobals newModule <> [glob]}
-            ModuleTest test -> pure $
-                newModule { mdTests = mdTests newModule <> [test] }
-            ModuleMemory mem -> do
-              case mdMemory newModule of
-                Nothing -> pure $ newModule { mdMemory = Just mem }
-                Just oldMem ->
-                  throwError (MultipleMemoryItems (imAnn oldMem) (imAnn mem))
-
-
-
-  in foldM withPart emptyModule parts
+resolveModule ::
+  (MonadError (ResolveModuleError ann) m) =>
+  [ModuleItem ann] ->
+  m (Module ann)
+resolveModule parts =
+  let emptyModule =
+        Module
+          { mdFunctions = mempty,
+            mdImports = mempty,
+            mdMemory = Nothing,
+            mdGlobals = mempty,
+            mdTests = mempty
+          }
+      withPart newModule item = case item of
+        ModuleFunction func ->
+          pure $
+            newModule {mdFunctions = mdFunctions newModule <> [func]}
+        ModuleImport imp ->
+          pure $
+            newModule {mdImports = mdImports newModule <> [imp]}
+        ModuleGlobal glob ->
+          pure $
+            newModule {mdGlobals = mdGlobals newModule <> [glob]}
+        ModuleTest test ->
+          pure $
+            newModule {mdTests = mdTests newModule <> [test]}
+        ModuleMemory mem -> do
+          case mdMemory newModule of
+            Nothing -> pure $ newModule {mdMemory = Just mem}
+            Just oldMem ->
+              throwError (MultipleMemoryItems (imAnn oldMem) (imAnn mem))
+   in foldM withPart emptyModule parts

--- a/wasm-calc10/src/Calc/Module.hs
+++ b/wasm-calc10/src/Calc/Module.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts   #-}
+module Calc.Module (resolveModule) where
+
+import           Calc.Types.Memory
+import           Calc.Types.Module
+import           Control.Monad        (foldM)
+import           Control.Monad.Except
+
+data ResolveModuleError ann = MultipleMemoryItems ann ann
+  deriving stock (Eq,Ord,Show, Functor)
+
+-- | turn lots of parts into a module
+resolveModule :: (MonadError (ResolveModuleError ann) m) =>
+  [ModuleItem ann] -> m (Module ann)
+resolveModule parts
+  = let emptyModule = Module {mdFunctions = mempty,mdImports = mempty,mdMemory = Nothing,
+            mdGlobals = mempty,mdTests = mempty}
+        withPart newModule item = case item of
+            ModuleFunction func -> pure $
+                newModule { mdFunctions = mdFunctions newModule <> [func] }
+            ModuleImport imp -> pure $
+                newModule { mdImports = mdImports newModule <> [imp] }
+            ModuleGlobal glob -> pure $
+                newModule { mdGlobals = mdGlobals newModule <> [glob]}
+            ModuleTest test -> pure $
+                newModule { mdTests = mdTests newModule <> [test] }
+            ModuleMemory mem -> do
+              case mdMemory newModule of
+                Nothing -> pure $ newModule { mdMemory = Just mem }
+                Just oldMem ->
+                  throwError (MultipleMemoryItems (imAnn oldMem) (imAnn mem))
+
+
+
+  in foldM withPart emptyModule parts

--- a/wasm-calc10/src/Calc/Parser.hs
+++ b/wasm-calc10/src/Calc/Parser.hs
@@ -15,17 +15,17 @@ module Calc.Parser
   )
 where
 
-import Calc.Parser.Expr
-import Calc.Parser.Function
-import Calc.Parser.Module
-import Calc.Parser.Pattern
-import Calc.Parser.Type
-import Calc.Parser.Types
-import Data.Bifunctor (first)
-import Data.Text (Text)
-import qualified Data.Text as T
-import Text.Megaparsec
-import Text.Megaparsec.Char
+import           Calc.Parser.Expr
+import           Calc.Parser.Function
+import           Calc.Parser.Module
+import           Calc.Parser.Pattern
+import           Calc.Parser.Type
+import           Calc.Parser.Types
+import           Data.Bifunctor       (first)
+import           Data.Text            (Text)
+import qualified Data.Text            as T
+import           Text.Megaparsec
+import           Text.Megaparsec.Char
 
 -- | which file are we parsing?
 -- we use this to show the right text in errors
@@ -63,11 +63,11 @@ parseFunctionAndFormatError = parseAndFormat (space *> functionParser <* eof)
 
 -- parse module, using it all up
 parseModule :: Text -> Either ParseErrorType ParserModule
-parseModule = parse (space *> moduleParser <* eof) replFilename
+parseModule = parse (space *> many moduleItemParser <* eof) replFilename
 
 -- | `parseModule`, but format error to text
 parseModuleAndFormatError :: Text -> Either Text ParserModule
-parseModuleAndFormatError = parseAndFormat (space *> moduleParser <* eof)
+parseModuleAndFormatError = parseAndFormat (space *> many moduleItemParser <* eof)
 
 -- parse pattern, using it all up
 parsePattern :: Text -> Either ParseErrorType ParserPattern

--- a/wasm-calc10/src/Calc/Parser.hs
+++ b/wasm-calc10/src/Calc/Parser.hs
@@ -15,17 +15,17 @@ module Calc.Parser
   )
 where
 
-import           Calc.Parser.Expr
-import           Calc.Parser.Function
-import           Calc.Parser.Module
-import           Calc.Parser.Pattern
-import           Calc.Parser.Type
-import           Calc.Parser.Types
-import           Data.Bifunctor       (first)
-import           Data.Text            (Text)
-import qualified Data.Text            as T
-import           Text.Megaparsec
-import           Text.Megaparsec.Char
+import Calc.Parser.Expr
+import Calc.Parser.Function
+import Calc.Parser.Module
+import Calc.Parser.Pattern
+import Calc.Parser.Type
+import Calc.Parser.Types
+import Data.Bifunctor (first)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Text.Megaparsec
+import Text.Megaparsec.Char
 
 -- | which file are we parsing?
 -- we use this to show the right text in errors

--- a/wasm-calc10/src/Calc/Parser/Module.hs
+++ b/wasm-calc10/src/Calc/Parser/Module.hs
@@ -1,23 +1,23 @@
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Calc.Parser.Module (moduleParser) where
+module Calc.Parser.Module (moduleParser,moduleItemParser) where
 
-import Calc.Parser.Expr
-import Calc.Parser.Function
-import Calc.Parser.Identifier
-import Calc.Parser.Import
-import Calc.Parser.Primitives
-import Calc.Parser.Shared
-import Calc.Parser.Type
-import Calc.Parser.Types
-import Calc.Types.Annotation
-import Calc.Types.Expr
-import Calc.Types.Global
-import Calc.Types.Memory
-import Calc.Types.Module
-import Calc.Types.Test
-import Text.Megaparsec
+import           Calc.Parser.Expr
+import           Calc.Parser.Function
+import           Calc.Parser.Identifier
+import           Calc.Parser.Import
+import           Calc.Parser.Primitives
+import           Calc.Parser.Shared
+import           Calc.Parser.Type
+import           Calc.Parser.Types
+import           Calc.Types.Annotation
+import           Calc.Types.Expr
+import           Calc.Types.Global
+import           Calc.Types.Memory
+import           Calc.Types.Module
+import           Calc.Types.Test
+import           Text.Megaparsec
 
 -- `memory 1000`
 localMemoryParser :: Parser (Memory Annotation)
@@ -50,7 +50,7 @@ mutabilityParser :: Parser Mutability
 mutabilityParser = myLexeme $ do
   maybeMut <- optional (stringLiteral "mut")
   case maybeMut of
-    Just _ -> pure Mutable
+    Just _  -> pure Mutable
     Nothing -> pure Constant
 
 -- `global dog = True`
@@ -88,6 +88,14 @@ testParser = myLexeme
     tesName <- identifierParser
     stringLiteral "="
     (,) tesName <$> exprParser
+
+moduleItemParser :: Parser (ModuleItem Annotation)
+moduleItemParser =
+  ModuleFunction <$> functionParser <|>
+    ModuleGlobal <$> globalParser <|>
+          ModuleTest <$> testParser <|>
+      try (ModuleMemory <$> memoryParser) <|>
+        ModuleImport <$> importParser
 
 -- we really need to parse all the different parts in any order then put them
 -- together in here

--- a/wasm-calc10/src/Calc/Parser/Module.hs
+++ b/wasm-calc10/src/Calc/Parser/Module.hs
@@ -1,23 +1,23 @@
-{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Calc.Parser.Module (moduleParser,moduleItemParser) where
+module Calc.Parser.Module (moduleParser, moduleItemParser) where
 
-import           Calc.Parser.Expr
-import           Calc.Parser.Function
-import           Calc.Parser.Identifier
-import           Calc.Parser.Import
-import           Calc.Parser.Primitives
-import           Calc.Parser.Shared
-import           Calc.Parser.Type
-import           Calc.Parser.Types
-import           Calc.Types.Annotation
-import           Calc.Types.Expr
-import           Calc.Types.Global
-import           Calc.Types.Memory
-import           Calc.Types.Module
-import           Calc.Types.Test
-import           Text.Megaparsec
+import Calc.Parser.Expr
+import Calc.Parser.Function
+import Calc.Parser.Identifier
+import Calc.Parser.Import
+import Calc.Parser.Primitives
+import Calc.Parser.Shared
+import Calc.Parser.Type
+import Calc.Parser.Types
+import Calc.Types.Annotation
+import Calc.Types.Expr
+import Calc.Types.Global
+import Calc.Types.Memory
+import Calc.Types.Module
+import Calc.Types.Test
+import Text.Megaparsec
 
 -- `memory 1000`
 localMemoryParser :: Parser (Memory Annotation)
@@ -50,7 +50,7 @@ mutabilityParser :: Parser Mutability
 mutabilityParser = myLexeme $ do
   maybeMut <- optional (stringLiteral "mut")
   case maybeMut of
-    Just _  -> pure Mutable
+    Just _ -> pure Mutable
     Nothing -> pure Constant
 
 -- `global dog = True`
@@ -91,11 +91,15 @@ testParser = myLexeme
 
 moduleItemParser :: Parser (ModuleItem Annotation)
 moduleItemParser =
-  ModuleFunction <$> functionParser <|>
-    ModuleGlobal <$> globalParser <|>
-          ModuleTest <$> testParser <|>
-      try (ModuleMemory <$> memoryParser) <|>
-        ModuleImport <$> importParser
+  ModuleFunction
+    <$> functionParser
+      <|> ModuleGlobal
+    <$> globalParser
+      <|> ModuleTest
+    <$> testParser
+      <|> try (ModuleMemory <$> memoryParser)
+      <|> ModuleImport
+    <$> importParser
 
 -- we really need to parse all the different parts in any order then put them
 -- together in here

--- a/wasm-calc10/src/Calc/Parser/Types.hs
+++ b/wasm-calc10/src/Calc/Parser/Types.hs
@@ -9,15 +9,15 @@ module Calc.Parser.Types
   )
 where
 
-import Calc.Types.Annotation
-import Calc.Types.Expr
-import Calc.Types.Function
-import Calc.Types.Module
-import Calc.Types.Pattern
-import Calc.Types.Type
-import Data.Text (Text)
-import Data.Void
-import Text.Megaparsec
+import           Calc.Types.Annotation
+import           Calc.Types.Expr
+import           Calc.Types.Function
+import           Calc.Types.Module
+import           Calc.Types.Pattern
+import           Calc.Types.Type
+import           Data.Text             (Text)
+import           Data.Void
+import           Text.Megaparsec
 
 type Parser = Parsec Void Text
 
@@ -29,6 +29,6 @@ type ParserType = Type Annotation
 
 type ParserFunction = Function Annotation
 
-type ParserModule = Module Annotation
+type ParserModule = [ModuleItem Annotation]
 
 type ParserPattern = Pattern Annotation

--- a/wasm-calc10/src/Calc/Parser/Types.hs
+++ b/wasm-calc10/src/Calc/Parser/Types.hs
@@ -9,15 +9,15 @@ module Calc.Parser.Types
   )
 where
 
-import           Calc.Types.Annotation
-import           Calc.Types.Expr
-import           Calc.Types.Function
-import           Calc.Types.Module
-import           Calc.Types.Pattern
-import           Calc.Types.Type
-import           Data.Text             (Text)
-import           Data.Void
-import           Text.Megaparsec
+import Calc.Types.Annotation
+import Calc.Types.Expr
+import Calc.Types.Function
+import Calc.Types.Module
+import Calc.Types.Pattern
+import Calc.Types.Type
+import Data.Text (Text)
+import Data.Void
+import Text.Megaparsec
 
 type Parser = Parsec Void Text
 

--- a/wasm-calc10/src/Calc/PrettyPrint.hs
+++ b/wasm-calc10/src/Calc/PrettyPrint.hs
@@ -1,31 +1,31 @@
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 {-# OPTIONS -Wno-orphans #-}
 
 module Calc.PrettyPrint
   ( prettyPrint,
     formatAndSave,
-    format
+    format,
   )
 where
 
-import           Calc.Parser
-import           Calc.Parser.Types
-import           Calc.Types.Module
-import           Control.Monad                    (when)
-import           Control.Monad.IO.Class
-import qualified Data.Text                        as T
-import qualified Data.Text.IO                     as T
-import           Data.Void
-import qualified Error.Diagnose                   as Diag
-import           Error.Diagnose.Compat.Megaparsec
-import qualified Prettyprinter                    as PP
-import qualified Prettyprinter.Render.Text        as PP
-import           System.Exit
+import Calc.Parser
+import Calc.Parser.Types
+import Calc.Types.Module
+import Control.Monad (when)
+import Control.Monad.IO.Class
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import Data.Void
+import qualified Error.Diagnose as Diag
+import Error.Diagnose.Compat.Megaparsec
+import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.Text as PP
+import System.Exit
 
 instance HasHints Void msg where
   hints _ = mempty
@@ -50,7 +50,7 @@ doPrettyPrint filePath = do
 format :: [ModuleItem ann] -> T.Text
 format parsedModuleItems = do
   let prettyMod = PP.cat (PP.punctuate PP.line (PP.pretty <$> parsedModuleItems))
-      in renderWithWidth 60 prettyMod
+   in renderWithWidth 60 prettyMod
 
 -- format the file, and if it's changed, save it
 formatAndSave :: (MonadIO m) => FilePath -> T.Text -> [ModuleItem ann] -> m ()

--- a/wasm-calc10/src/Calc/Repl.hs
+++ b/wasm-calc10/src/Calc/Repl.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings     #-}
 
 {-# OPTIONS -Wno-orphans #-}
 
@@ -11,26 +11,25 @@ module Calc.Repl
   )
 where
 
-import Calc.Ability.Check
-import Calc.Linearity
-  ( linearityErrorDiagnostic,
-    validateModule,
-  )
-import Calc.Parser
-import Calc.Parser.Types
-import Calc.Typecheck
-import Calc.Wasm.FromExpr.Module
-import Calc.Wasm.Run
-import Calc.Wasm.ToWasm.Module
-import Calc.Wasm.ToWasm.Types
-import Control.Monad.IO.Class
-import Data.Text (Text)
-import qualified Data.Text as T
-import Data.Void
-import qualified Error.Diagnose as Diag
-import Error.Diagnose.Compat.Megaparsec
-import qualified Language.Wasm.Interpreter as Wasm
-import System.Console.Haskeline
+import           Calc.Ability.Check
+import           Calc.Linearity                   (linearityErrorDiagnostic,
+                                                   validateModule)
+import           Calc.Module                      (resolveModule)
+import           Calc.Parser
+import           Calc.Parser.Types
+import           Calc.Typecheck
+import           Calc.Wasm.FromExpr.Module
+import           Calc.Wasm.Run
+import           Calc.Wasm.ToWasm.Module
+import           Calc.Wasm.ToWasm.Types
+import           Control.Monad.IO.Class
+import           Data.Text                        (Text)
+import qualified Data.Text                        as T
+import           Data.Void
+import qualified Error.Diagnose                   as Diag
+import           Error.Diagnose.Compat.Megaparsec
+import qualified Language.Wasm.Interpreter        as Wasm
+import           System.Console.Haskeline
 
 instance HasHints Void msg where
   hints _ = mempty
@@ -52,29 +51,33 @@ repl = do
             Left bundle -> do
               printDiagnostic (fromErrorBundle bundle input)
               loop
-            Right parsedModule -> case elaborateModule parsedModule of
-              Left typeErr -> do
-                printDiagnostic (typeErrorDiagnostic (T.pack input) typeErr)
-                loop
-              Right typedMod ->
-                case validateModule typedMod of
-                  Left linearityError -> do
-                    printDiagnostic (linearityErrorDiagnostic (T.pack input) linearityError)
-                    loop
-                  Right _ -> do
-                    case abilityCheckModule parsedModule of
-                      Left abilityError -> do
-                        printDiagnostic (abilityErrorDiagnostic (T.pack input) abilityError)
-                        loop
-                      Right _ ->
-                        case fromModule typedMod of
-                          Left _fromWasmError -> do
-                            -- printDiagnostic "From Wasm Error"
-                            loop
-                          Right wasmMod -> do
-                            resp <- liftIO $ runWasmModule wasmMod
-                            liftIO $ putStrLn resp
-                            loop
+            Right parsedModuleItems -> case resolveModule parsedModuleItems of
+                                         Left err -> liftIO (print err) >> loop
+                                         Right parsedModule ->
+
+                                            case elaborateModule parsedModule of
+                                            Left typeErr -> do
+                                              printDiagnostic (typeErrorDiagnostic (T.pack input) typeErr)
+                                              loop
+                                            Right typedMod ->
+                                              case validateModule typedMod of
+                                                Left linearityError -> do
+                                                  printDiagnostic (linearityErrorDiagnostic (T.pack input) linearityError)
+                                                  loop
+                                                Right _ -> do
+                                                  case abilityCheckModule parsedModule of
+                                                    Left abilityError -> do
+                                                      printDiagnostic (abilityErrorDiagnostic (T.pack input) abilityError)
+                                                      loop
+                                                    Right _ ->
+                                                      case fromModule typedMod of
+                                                        Left _fromWasmError -> do
+                                                          -- printDiagnostic "From Wasm Error"
+                                                          loop
+                                                        Right wasmMod -> do
+                                                          resp <- liftIO $ runWasmModule wasmMod
+                                                          liftIO $ putStrLn resp
+                                                          loop
 
 -- if input does not include `function`, wrap it in
 -- `function main() { <input> }`

--- a/wasm-calc10/src/Calc/Types/Module.hs
+++ b/wasm-calc10/src/Calc/Types/Module.hs
@@ -1,23 +1,43 @@
-{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFunctor      #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NamedFieldPuns     #-}
 
-module Calc.Types.Module (Module (..)) where
+module Calc.Types.Module (Module (..),ModuleItem(..)) where
 
-import Calc.Types.Function
-import Calc.Types.Global
-import Calc.Types.Import
-import Calc.Types.Memory
-import Calc.Types.Test
-import Data.Maybe (maybeToList)
-import qualified Prettyprinter as PP
+import           Calc.Types.Function
+import           Calc.Types.Global
+import           Calc.Types.Import
+import           Calc.Types.Memory
+import           Calc.Types.Test
+import           Data.Maybe          (maybeToList)
+import qualified Prettyprinter       as PP
+
+-- | in order to parse these items in any order, we parse zero or more items
+-- and then turn them into a `Module` later
+-- This allows us to pretty print in the original order
+data ModuleItem ann =
+  ModuleFunction (Function ann)
+    | ModuleImport (Import ann)
+    | ModuleMemory (Memory ann)
+    | ModuleGlobal (Global ann)
+    | ModuleTest (Test ann)
+  deriving stock (Eq,Ord,Show,Functor)
+
+instance PP.Pretty (ModuleItem ann) where
+  pretty (ModuleFunction func) =
+    PP.pretty func
+  pretty (ModuleImport imp) =
+    PP.pretty imp
+  pretty (ModuleMemory mem) = PP.pretty mem
+  pretty (ModuleGlobal glob) = PP.pretty glob
+  pretty (ModuleTest test) =  PP.pretty test
 
 data Module ann = Module
   { mdFunctions :: [Function ann],
-    mdImports :: [Import ann],
-    mdMemory :: Maybe (Memory ann),
-    mdGlobals :: [Global ann],
-    mdTests :: [Test ann]
+    mdImports   :: [Import ann],
+    mdMemory    :: Maybe (Memory ann),
+    mdGlobals   :: [Global ann],
+    mdTests     :: [Test ann]
   }
   deriving stock (Eq, Ord, Show, Functor)
 

--- a/wasm-calc10/src/Calc/Types/Module.hs
+++ b/wasm-calc10/src/Calc/Types/Module.hs
@@ -1,27 +1,27 @@
-{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
-module Calc.Types.Module (Module (..),ModuleItem(..)) where
+module Calc.Types.Module (Module (..), ModuleItem (..)) where
 
-import           Calc.Types.Function
-import           Calc.Types.Global
-import           Calc.Types.Import
-import           Calc.Types.Memory
-import           Calc.Types.Test
-import           Data.Maybe          (maybeToList)
-import qualified Prettyprinter       as PP
+import Calc.Types.Function
+import Calc.Types.Global
+import Calc.Types.Import
+import Calc.Types.Memory
+import Calc.Types.Test
+import Data.Maybe (maybeToList)
+import qualified Prettyprinter as PP
 
 -- | in order to parse these items in any order, we parse zero or more items
 -- and then turn them into a `Module` later
 -- This allows us to pretty print in the original order
-data ModuleItem ann =
-  ModuleFunction (Function ann)
-    | ModuleImport (Import ann)
-    | ModuleMemory (Memory ann)
-    | ModuleGlobal (Global ann)
-    | ModuleTest (Test ann)
-  deriving stock (Eq,Ord,Show,Functor)
+data ModuleItem ann
+  = ModuleFunction (Function ann)
+  | ModuleImport (Import ann)
+  | ModuleMemory (Memory ann)
+  | ModuleGlobal (Global ann)
+  | ModuleTest (Test ann)
+  deriving stock (Eq, Ord, Show, Functor)
 
 instance PP.Pretty (ModuleItem ann) where
   pretty (ModuleFunction func) =
@@ -30,14 +30,14 @@ instance PP.Pretty (ModuleItem ann) where
     PP.pretty imp
   pretty (ModuleMemory mem) = PP.pretty mem
   pretty (ModuleGlobal glob) = PP.pretty glob
-  pretty (ModuleTest test) =  PP.pretty test
+  pretty (ModuleTest test) = PP.pretty test
 
 data Module ann = Module
   { mdFunctions :: [Function ann],
-    mdImports   :: [Import ann],
-    mdMemory    :: Maybe (Memory ann),
-    mdGlobals   :: [Global ann],
-    mdTests     :: [Test ann]
+    mdImports :: [Import ann],
+    mdMemory :: Maybe (Memory ann),
+    mdGlobals :: [Global ann],
+    mdTests :: [Test ann]
   }
   deriving stock (Eq, Ord, Show, Functor)
 

--- a/wasm-calc10/test/Test/Ability/AbilitySpec.hs
+++ b/wasm-calc10/test/Test/Ability/AbilitySpec.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Ability.AbilitySpec (spec) where
 
-import           Calc
-import           Calc.Ability.Check
-import           Calc.Module
-import           Control.Monad      (void)
-import           Data.Foldable      (traverse_)
-import qualified Data.Map.Strict    as M
-import qualified Data.Set           as S
-import qualified Data.Text          as T
-import           Test.Helpers
-import           Test.Hspec
+import Calc
+import Calc.Ability.Check
+import Calc.Module
+import Control.Monad (void)
+import Data.Foldable (traverse_)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import qualified Data.Text as T
+import Test.Helpers
+import Test.Hspec
 
 voidModuleAbilities :: ModuleAbilities ann -> ModuleAbilities ()
 voidModuleAbilities moduleAbilities =

--- a/wasm-calc10/test/Test/Ability/AbilitySpec.hs
+++ b/wasm-calc10/test/Test/Ability/AbilitySpec.hs
@@ -1,17 +1,18 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Ability.AbilitySpec (spec) where
 
-import Calc
-import Calc.Ability.Check
-import Control.Monad (void)
-import Data.Foldable (traverse_)
-import qualified Data.Map.Strict as M
-import qualified Data.Set as S
-import qualified Data.Text as T
-import Test.Helpers
-import Test.Hspec
+import           Calc
+import           Calc.Ability.Check
+import           Calc.Module
+import           Control.Monad      (void)
+import           Data.Foldable      (traverse_)
+import qualified Data.Map.Strict    as M
+import qualified Data.Set           as S
+import qualified Data.Text          as T
+import           Test.Helpers
+import           Test.Hspec
 
 voidModuleAbilities :: ModuleAbilities ann -> ModuleAbilities ()
 voidModuleAbilities moduleAbilities =
@@ -85,9 +86,12 @@ spec = do
         traverse_
           ( \(str, abilityResult) -> it (T.unpack str) $ do
               case parseModuleAndFormatError str of
-                Right parsedModule -> do
-                  voidModuleAbilities (fromRight (abilityCheckModule parsedModule))
-                    `shouldBe` abilityResult
+                Right parsedModuleItems ->
+                  case resolveModule parsedModuleItems of
+                    Left e -> error (show e)
+                    Right parsedModule ->
+                      voidModuleAbilities (fromRight (abilityCheckModule parsedModule))
+                        `shouldBe` abilityResult
                 Left e -> error (T.unpack e)
           )
           successes
@@ -122,9 +126,12 @@ spec = do
         traverse_
           ( \(str, abilityError) -> it (T.unpack str) $ do
               case parseModuleAndFormatError str of
-                Right parsedModule -> do
-                  void (fromLeft (abilityCheckModule parsedModule))
-                    `shouldBe` abilityError
+                Right parsedModuleItems ->
+                  case resolveModule parsedModuleItems of
+                    Left e -> error (show e)
+                    Right parsedModule ->
+                      void (fromLeft (abilityCheckModule parsedModule))
+                        `shouldBe` abilityError
                 Left e -> error (T.unpack e)
           )
           failures

--- a/wasm-calc10/test/Test/Parser/ParserSpec.hs
+++ b/wasm-calc10/test/Test/Parser/ParserSpec.hs
@@ -2,14 +2,15 @@
 
 module Test.Parser.ParserSpec (spec) where
 
-import Calc
-import Data.Foldable (traverse_)
-import Data.Functor
+import           Calc
+import           Calc.Module
+import           Data.Foldable      (traverse_)
+import           Data.Functor
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Set as S
-import qualified Data.Text as T
-import Test.Helpers
-import Test.Hspec
+import qualified Data.Set           as S
+import qualified Data.Text          as T
+import           Test.Helpers
+import           Test.Hspec
 
 emptyFunction :: Function ()
 emptyFunction =
@@ -41,7 +42,7 @@ spec = do
         ( \(str, expr) -> it (T.unpack str) $ do
             case parseTypeAndFormatError str of
               Right parsedExp -> parsedExp $> () `shouldBe` expr
-              Left e -> error (T.unpack e)
+              Left e          -> error (T.unpack e)
         )
         strings
 
@@ -219,8 +220,12 @@ spec = do
       traverse_
         ( \(str, module') -> it (T.unpack str) $ do
             case parseModuleAndFormatError str of
-              Right parsedMod -> parsedMod $> () `shouldBe` module'
               Left e -> error (T.unpack e)
+              Right parsedModuleItems ->
+                case resolveModule parsedModuleItems of
+                  Left e -> error (show e)
+                  Right parsedMod ->
+                    parsedMod $> () `shouldBe` module'
         )
         strings
 
@@ -303,7 +308,7 @@ spec = do
         ( \(str, fn) -> it (T.unpack str) $ do
             case parseFunctionAndFormatError str of
               Right parsedFn -> parsedFn $> () `shouldBe` fn
-              Left e -> error (T.unpack e)
+              Left e         -> error (T.unpack e)
         )
         strings
 
@@ -317,7 +322,7 @@ spec = do
         ( \(str, pat) -> it (T.unpack str) $ do
             case parsePatternAndFormatError str of
               Right parsedPattern -> parsedPattern $> () `shouldBe` pat
-              Left e -> error (T.unpack e)
+              Left e              -> error (T.unpack e)
         )
         strings
 
@@ -377,7 +382,7 @@ spec = do
         ( \(str, expr) -> it (T.unpack str) $ do
             case parseExprAndFormatError str of
               Right parsedExp -> parsedExp $> () `shouldBe` expr
-              Left e -> error (T.unpack e)
+              Left e          -> error (T.unpack e)
         )
         strings
 

--- a/wasm-calc10/test/Test/Parser/ParserSpec.hs
+++ b/wasm-calc10/test/Test/Parser/ParserSpec.hs
@@ -2,15 +2,15 @@
 
 module Test.Parser.ParserSpec (spec) where
 
-import           Calc
-import           Calc.Module
-import           Data.Foldable      (traverse_)
-import           Data.Functor
+import Calc
+import Calc.Module
+import Data.Foldable (traverse_)
+import Data.Functor
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Set           as S
-import qualified Data.Text          as T
-import           Test.Helpers
-import           Test.Hspec
+import qualified Data.Set as S
+import qualified Data.Text as T
+import Test.Helpers
+import Test.Hspec
 
 emptyFunction :: Function ()
 emptyFunction =
@@ -42,7 +42,7 @@ spec = do
         ( \(str, expr) -> it (T.unpack str) $ do
             case parseTypeAndFormatError str of
               Right parsedExp -> parsedExp $> () `shouldBe` expr
-              Left e          -> error (T.unpack e)
+              Left e -> error (T.unpack e)
         )
         strings
 
@@ -308,7 +308,7 @@ spec = do
         ( \(str, fn) -> it (T.unpack str) $ do
             case parseFunctionAndFormatError str of
               Right parsedFn -> parsedFn $> () `shouldBe` fn
-              Left e         -> error (T.unpack e)
+              Left e -> error (T.unpack e)
         )
         strings
 
@@ -322,7 +322,7 @@ spec = do
         ( \(str, pat) -> it (T.unpack str) $ do
             case parsePatternAndFormatError str of
               Right parsedPattern -> parsedPattern $> () `shouldBe` pat
-              Left e              -> error (T.unpack e)
+              Left e -> error (T.unpack e)
         )
         strings
 
@@ -382,7 +382,7 @@ spec = do
         ( \(str, expr) -> it (T.unpack str) $ do
             case parseExprAndFormatError str of
               Right parsedExp -> parsedExp $> () `shouldBe` expr
-              Left e          -> error (T.unpack e)
+              Left e -> error (T.unpack e)
         )
         strings
 

--- a/wasm-calc10/test/Test/PrettyPrint/PrettyPrintSpec.hs
+++ b/wasm-calc10/test/Test/PrettyPrint/PrettyPrintSpec.hs
@@ -1,28 +1,21 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell   #-}
 
 -- | test evaluating and running tests for a module
 module Test.PrettyPrint.PrettyPrintSpec (spec) where
 
-import qualified Calc.Parser as Parse
-import Calc.Types.Module
-import Data.Bifunctor (second)
-import Data.FileEmbed
-import Data.Foldable (traverse_)
-import Data.Functor
-import Data.Text (Text)
-import qualified Data.Text as T
+import qualified Calc.Parser        as Parse
+import           Calc.PrettyPrint
+import           Calc.Types.Module
+import           Data.Bifunctor     (second)
+import           Data.FileEmbed
+import           Data.Foldable      (traverse_)
+import           Data.Functor
+import           Data.Text          (Text)
 import qualified Data.Text.Encoding as T
-import qualified Prettyprinter as PP
-import qualified Prettyprinter.Render.Text as PP
-import Test.Hspec
-
-renderWithWidth :: Int -> PP.Doc ann -> T.Text
-renderWithWidth w doc = PP.renderStrict (PP.layoutPretty layoutOptions (PP.unAnnotate doc))
-  where
-    layoutOptions = PP.LayoutOptions {PP.layoutPageWidth = PP.AvailablePerLine w 1}
+import           Test.Hspec
 
 -- these are saved in a file that is included in compilation
 testInputs :: [(FilePath, Text)]
@@ -30,11 +23,11 @@ testInputs =
   fmap (second T.decodeUtf8) $(makeRelativeToProject "test/static/" >>= embedDir)
 
 -- read a module, pretty print it, is it the same?
-parseModule :: Text -> Module ()
+parseModule :: Text -> [ModuleItem ()]
 parseModule input =
   case Parse.parseModuleAndFormatError input of
-    Left e -> error (show e)
-    Right parts -> parts $> ()
+    Left e      -> error (show e)
+    Right parts -> void <$> parts
 
 spec :: Spec
 spec = do
@@ -43,7 +36,7 @@ spec = do
       let printModule (filepath, input) =
             it ("Pretty pretting " <> filepath <> " round trips successfully") $ do
               let parts = parseModule input
-                  printed = renderWithWidth 60 $ PP.pretty parts
+                  printed = format parts
               let parts2 = parseModule printed
               parts2 `shouldBe` parts
       traverse_ printModule testInputs
@@ -52,6 +45,6 @@ spec = do
       let printModule (filepath, input) =
             it ("Pretty pretting " <> filepath <> " is the same") $ do
               let parts = parseModule input
-                  printed = renderWithWidth 60 $ PP.pretty parts
+                  printed = format parts
               printed `shouldBe` input
       traverse_ printModule testInputs

--- a/wasm-calc10/test/Test/PrettyPrint/PrettyPrintSpec.hs
+++ b/wasm-calc10/test/Test/PrettyPrint/PrettyPrintSpec.hs
@@ -1,21 +1,21 @@
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- | test evaluating and running tests for a module
 module Test.PrettyPrint.PrettyPrintSpec (spec) where
 
-import qualified Calc.Parser        as Parse
-import           Calc.PrettyPrint
-import           Calc.Types.Module
-import           Data.Bifunctor     (second)
-import           Data.FileEmbed
-import           Data.Foldable      (traverse_)
-import           Data.Functor
-import           Data.Text          (Text)
+import qualified Calc.Parser as Parse
+import Calc.PrettyPrint
+import Calc.Types.Module
+import Data.Bifunctor (second)
+import Data.FileEmbed
+import Data.Foldable (traverse_)
+import Data.Functor
+import Data.Text (Text)
 import qualified Data.Text.Encoding as T
-import           Test.Hspec
+import Test.Hspec
 
 -- these are saved in a file that is included in compilation
 testInputs :: [(FilePath, Text)]
@@ -26,7 +26,7 @@ testInputs =
 parseModule :: Text -> [ModuleItem ()]
 parseModule input =
   case Parse.parseModuleAndFormatError input of
-    Left e      -> error (show e)
+    Left e -> error (show e)
     Right parts -> void <$> parts
 
 spec :: Spec

--- a/wasm-calc10/test/Test/Typecheck/TypecheckSpec.hs
+++ b/wasm-calc10/test/Test/Typecheck/TypecheckSpec.hs
@@ -1,25 +1,25 @@
-{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Typecheck.TypecheckSpec (spec) where
 
-import           Calc.ExprUtils
-import           Calc.Module
-import           Calc.Parser
-import           Calc.Typecheck
-import           Calc.Types.Function
-import           Calc.Types.Module
-import           Calc.Types.Op
-import           Calc.Types.Pattern
-import           Calc.Types.Type
-import           Control.Monad
-import           Data.Either         (isLeft)
-import           Data.Foldable       (traverse_)
-import qualified Data.List           as List
-import qualified Data.List.NonEmpty  as NE
-import           Data.Text           (Text)
-import           Test.Helpers
-import           Test.Hspec
+import Calc.ExprUtils
+import Calc.Module
+import Calc.Parser
+import Calc.Typecheck
+import Calc.Types.Function
+import Calc.Types.Module
+import Calc.Types.Op
+import Calc.Types.Pattern
+import Calc.Types.Type
+import Control.Monad
+import Data.Either (isLeft)
+import Data.Foldable (traverse_)
+import qualified Data.List as List
+import qualified Data.List.NonEmpty as NE
+import Data.Text (Text)
+import Test.Helpers
+import Test.Hspec
 
 runTC :: TypecheckM ann a -> Either (TypeError ann) a
 runTC = runTypecheckM (TypecheckEnv mempty mempty 0)

--- a/wasm-calc10/test/Test/Wasm/WasmSpec.hs
+++ b/wasm-calc10/test/Test/Wasm/WasmSpec.hs
@@ -1,27 +1,27 @@
-{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Wasm.WasmSpec (spec) where
 
-import           Calc.Dependencies
-import           Calc.Linearity            (validateModule)
-import           Calc.Module
-import           Calc.Parser
-import           Calc.Test
-import           Calc.Typecheck
-import           Calc.Wasm
+import Calc.Dependencies
+import Calc.Linearity (validateModule)
+import Calc.Module
+import Calc.Parser
+import Calc.Test
+import Calc.Typecheck
+import Calc.Wasm
 import qualified Calc.Wasm.FromExpr.Module as FromExpr
-import           Calc.Wasm.Run
-import qualified Calc.Wasm.ToWasm          as ToWasm
-import           Control.Monad.IO.Class
-import           Data.Foldable             (traverse_)
-import           Data.Hashable             (hash)
-import qualified Data.Text                 as T
+import Calc.Wasm.Run
+import qualified Calc.Wasm.ToWasm as ToWasm
+import Control.Monad.IO.Class
+import Data.Foldable (traverse_)
+import Data.Hashable (hash)
+import qualified Data.Text as T
 import qualified Language.Wasm.Interpreter as Wasm
-import qualified Language.Wasm.Structure   as Wasm
-import           Test.Helpers
-import           Test.Hspec
-import           Test.RunNode
+import qualified Language.Wasm.Structure as Wasm
+import Test.Helpers
+import Test.Hspec
+import Test.RunNode
 
 -- | compile module or spit out error
 compile :: T.Text -> Wasm.Module

--- a/wasm-calc10/test/static/drawing.calc
+++ b/wasm-calc10/test/static/drawing.calc
@@ -2,10 +2,6 @@ global i: Int32 = 100
 
 global mut j = True
 
-import imports.draw as draw(
-  x: Int8, y: Int8, r: Int8, g: Int8, b: Int8
-) -> Void
-
 function min(floor: Int8, value: Int8) -> Int8 { 
   if value > floor then value else floor
 }
@@ -13,6 +9,10 @@ function min(floor: Int8, value: Int8) -> Int8 {
 function max(ceiling: Int8, value: Int8) -> Int8 { 
   if value < ceiling then value else ceiling
 }
+
+import imports.draw as draw(
+  x: Int8, y: Int8, r: Int8, g: Int8, b: Int8
+) -> Void
 
 function clamp(
   floor: Int8, ceiling: Int8, value: Int8

--- a/wasm-calc10/wasm-calc10.cabal
+++ b/wasm-calc10/wasm-calc10.cabal
@@ -62,6 +62,7 @@ common shared
     Calc.Linearity.Error
     Calc.Linearity.Types
     Calc.Linearity.Validate
+    Calc.Module
     Calc.Parser
     Calc.Parser.Expr
     Calc.Parser.Function


### PR DESCRIPTION
Previously there was a set ordering to parser items, let's not bother with that anymore.