### PR TITLE
Parse data types

### DIFF
--- a/wasm-calc10/src/Calc/Parser.hs
+++ b/wasm-calc10/src/Calc/Parser.hs
@@ -11,10 +11,13 @@ module Calc.Parser
     parseModuleAndFormatError,
     parsePattern,
     parsePatternAndFormatError,
+    parseData,
+    parseDataAndFormatError,
     replFilename,
   )
 where
 
+import Calc.Parser.Data
 import Calc.Parser.Expr
 import Calc.Parser.Function
 import Calc.Parser.Module
@@ -76,3 +79,11 @@ parsePattern = parse (space *> patternParser <* eof) replFilename
 -- | `parsePattern`, but format error to text
 parsePatternAndFormatError :: Text -> Either Text ParserPattern
 parsePatternAndFormatError = parseAndFormat (space *> patternParser <* eof)
+
+-- parse data type, using it all up
+parseData :: Text -> Either ParseErrorType ParserData
+parseData = parse (space *> dataParser <* eof) replFilename
+
+-- | `parseData`, but format error to text
+parseDataAndFormatError :: Text -> Either Text ParserData
+parseDataAndFormatError = parseAndFormat (space *> dataParser <* eof)

--- a/wasm-calc10/src/Calc/Parser/Data.hs
+++ b/wasm-calc10/src/Calc/Parser/Data.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Calc.Parser.Data (dataParser) where
+
+import Calc.Parser.Identifier
+import Calc.Parser.Shared
+import Calc.Parser.Type
+import Calc.Types
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Data.Void (Void)
+import Text.Megaparsec
+
+type Parser = Parsec Void Text
+
+dataParser :: Parser (Data Annotation)
+dataParser =
+  try typeDeclParserWithCons
+    <|> typeDeclParserEmpty
+
+---------------------
+
+-- it's your "type Void in ..."
+typeDeclParserEmpty :: Parser (Data Annotation)
+typeDeclParserEmpty = do
+  stringLiteral "type"
+  tyName <- dataNameParser
+  pure (Data tyName mempty mempty)
+
+-- it's your more complex cases
+typeDeclParserWithCons :: Parser (Data Annotation)
+typeDeclParserWithCons = do
+  stringLiteral "type"
+  tyName <- dataNameParser
+  tyArgs <- many identifierParser
+  stringLiteral "="
+  Data tyName tyArgs <$> manyTypeConstructors
+
+--------
+
+manyTypeConstructors :: Parser (Map Constructor [Type Annotation])
+manyTypeConstructors = do
+  tyCons <-
+    sepBy
+      oneTypeConstructor
+      (stringLiteral "|")
+  pure (mconcat tyCons)
+
+-----
+
+oneTypeConstructor :: Parser (Map Constructor [Type Annotation])
+oneTypeConstructor = do
+  constructor <- myLexeme constructorParserInternal
+  args <-
+    some typeParser -- (try simpleTypeParser <|> inBrackets typeParser)
+      <|> pure mempty
+  pure (M.singleton constructor args)

--- a/wasm-calc10/src/Calc/Parser/Function.hs
+++ b/wasm-calc10/src/Calc/Parser/Function.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Calc.Parser.Function (functionParser, functionNameParser) where
+module Calc.Parser.Function (functionParser, functionNameParser, genericsParser) where
 
 import Calc.Parser.Expr
 import Calc.Parser.Identifier

--- a/wasm-calc10/src/Calc/Parser/Types.hs
+++ b/wasm-calc10/src/Calc/Parser/Types.hs
@@ -6,10 +6,12 @@ module Calc.Parser.Types
     ParserFunction,
     ParserModule,
     ParserPattern,
+    ParserData,
   )
 where
 
 import Calc.Types.Annotation
+import Calc.Types.Data
 import Calc.Types.Expr
 import Calc.Types.Function
 import Calc.Types.Module
@@ -32,3 +34,5 @@ type ParserFunction = Function Annotation
 type ParserModule = [ModuleItem Annotation]
 
 type ParserPattern = Pattern Annotation
+
+type ParserData = Data Annotation

--- a/wasm-calc10/src/Calc/Types.hs
+++ b/wasm-calc10/src/Calc/Types.hs
@@ -1,6 +1,8 @@
 module Calc.Types
   ( module Calc.Types.Annotation,
     module Calc.Types.Op,
+    module Calc.Types.Constructor,
+    module Calc.Types.Data,
     module Calc.Types.Identifier,
     module Calc.Types.Import,
     module Calc.Types.Expr,
@@ -19,6 +21,8 @@ where
 
 import Calc.Types.Ability
 import Calc.Types.Annotation
+import Calc.Types.Constructor
+import Calc.Types.Data
 import Calc.Types.Expr
 import Calc.Types.Function
 import Calc.Types.Global

--- a/wasm-calc10/src/Calc/Types/Constructor.hs
+++ b/wasm-calc10/src/Calc/Types/Constructor.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Calc.Types.Constructor
+  ( Constructor (..),
+    safeMkConstructor,
+    mkConstructor,
+  )
+where
+
+import qualified Data.Char as Ch
+import Data.String
+import qualified Data.Text as T
+import qualified Prettyprinter as PP
+
+newtype Constructor = Constructor T.Text
+  deriving newtype
+    ( Eq,
+      Ord,
+      Show,
+      Semigroup
+    )
+
+instance PP.Pretty Constructor where
+  pretty (Constructor c) = PP.pretty c
+
+instance IsString Constructor where
+  fromString = Constructor . T.pack
+
+validConstructor :: T.Text -> Bool
+validConstructor a =
+  not (T.null a)
+    && T.filter Ch.isAlphaNum a == a
+    && not (Ch.isDigit (T.head a))
+    && Ch.isUpper (T.head a)
+
+mkConstructor :: T.Text -> Constructor
+mkConstructor a =
+  if validConstructor a
+    then Constructor a
+    else error $ T.unpack $ "Constructor validation fail for '" <> a <> "'"
+
+safeMkConstructor :: T.Text -> Maybe Constructor
+safeMkConstructor a =
+  if validConstructor a
+    then Just (Constructor a)
+    else Nothing

--- a/wasm-calc10/src/Calc/Types/Data.hs
+++ b/wasm-calc10/src/Calc/Types/Data.hs
@@ -5,8 +5,8 @@
 module Calc.Types.Data (Data (..), DataName (..), Constructor (..)) where
 
 import Calc.Types.Constructor
-import Calc.Types.Identifier
 import Calc.Types.Type
+import Calc.Types.TypeVar
 import qualified Data.Map.Strict as M
 
 newtype DataName = DataName Constructor
@@ -14,7 +14,7 @@ newtype DataName = DataName Constructor
 
 data Data ann = Data
   { dtName :: DataName,
-    dtVars :: [Identifier],
+    dtVars :: [TypeVar],
     dtConstructors :: M.Map Constructor [Type ann]
   }
   deriving stock (Eq, Ord, Show, Functor)

--- a/wasm-calc10/src/Calc/Types/Data.hs
+++ b/wasm-calc10/src/Calc/Types/Data.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+
+module Calc.Types.Data (Data (..), DataName (..), Constructor (..)) where
+
+import Calc.Types.Constructor
+import Calc.Types.Identifier
+import Calc.Types.Type
+import qualified Data.Map.Strict as M
+
+newtype DataName = DataName Constructor
+  deriving newtype (Eq, Ord, Show)
+
+data Data ann = Data
+  { dtName :: DataName,
+    dtVars :: [Identifier],
+    dtConstructors :: M.Map Constructor [Type ann]
+  }
+  deriving stock (Eq, Ord, Show, Functor)

--- a/wasm-calc10/test/Test/Parser/ParserSpec.hs
+++ b/wasm-calc10/test/Test/Parser/ParserSpec.hs
@@ -7,6 +7,7 @@ import Calc.Module
 import Data.Foldable (traverse_)
 import Data.Functor
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Test.Helpers
@@ -226,6 +227,39 @@ spec = do
                   Left e -> error (show e)
                   Right parsedMod ->
                     parsedMod $> () `shouldBe` module'
+        )
+        strings
+
+    describe "Data" $ do
+      let strings =
+            [ ( "type Colour = Red | Green | Blue",
+                Data
+                  { dtName = DataName "Colour",
+                    dtVars = mempty,
+                    dtConstructors =
+                      M.fromList
+                        [ ("Red", mempty),
+                          ("Green", mempty),
+                          ("Blue", mempty)
+                        ]
+                  }
+              ),
+              ( "type Void",
+                Data {dtName = DataName "Void", dtVars = mempty, dtConstructors = mempty}
+              ),
+              ( "type Proxy a = Proxy",
+                Data
+                  { dtName = DataName "Proxy",
+                    dtVars = ["a"],
+                    dtConstructors = M.singleton "Proxy" mempty
+                  }
+              )
+            ]
+      traverse_
+        ( \(str, dt) -> it (T.unpack str) $ do
+            case parseDataAndFormatError str of
+              Right parsedData -> parsedData $> () `shouldBe` dt
+              Left e -> error (T.unpack e)
         )
         strings
 

--- a/wasm-calc10/test/Test/Parser/ParserSpec.hs
+++ b/wasm-calc10/test/Test/Parser/ParserSpec.hs
@@ -247,11 +247,34 @@ spec = do
               ( "type Void",
                 Data {dtName = DataName "Void", dtVars = mempty, dtConstructors = mempty}
               ),
-              ( "type Proxy a = Proxy",
+              ( "type Proxy<a> = Proxy",
                 Data
                   { dtName = DataName "Proxy",
                     dtVars = ["a"],
                     dtConstructors = M.singleton "Proxy" mempty
+                  }
+              ),
+              ( "type Either<e,a> = Left(e) | Right(a)",
+                Data
+                  { dtName = DataName "Either",
+                    dtVars = ["e", "a"],
+                    dtConstructors =
+                      M.fromList
+                        [ ("Left", [TVar mempty "e"]),
+                          ("Right", [TVar mempty "a"])
+                        ]
+                  }
+              ),
+              ( "type These<a,b> = This(a) | That(b) | These(a,b)",
+                Data
+                  { dtName = DataName "These",
+                    dtVars = ["a", "b"],
+                    dtConstructors =
+                      M.fromList
+                        [ ("This", [TVar mempty "a"]),
+                          ("That", [TVar mempty "b"]),
+                          ("These", [TVar mempty "a", TVar mempty "b"])
+                        ]
                   }
               )
             ]

--- a/wasm-calc10/wasm-calc10.cabal
+++ b/wasm-calc10/wasm-calc10.cabal
@@ -64,6 +64,7 @@ common shared
     Calc.Linearity.Validate
     Calc.Module
     Calc.Parser
+    Calc.Parser.Data
     Calc.Parser.Expr
     Calc.Parser.Function
     Calc.Parser.Identifier
@@ -90,6 +91,8 @@ common shared
     Calc.Types
     Calc.Types.Ability
     Calc.Types.Annotation
+    Calc.Types.Constructor
+    Calc.Types.Data
     Calc.Types.Expr
     Calc.Types.Function
     Calc.Types.FunctionName


### PR DESCRIPTION
Let's decide on our syntax. We don't have structs yet so really it's just discriminators plus tuples of data.

Simple enums:

`type Colour = Red | Green | Blue`

These are just fancy ints under the hood.

Void:

`type Void`

Attaching values:

`type Either e a = Left(e) | Right(a)`

`Either Int16 Bool` becomes either `(Int8, Int16)` or `(Int8, Bool)`, using Int8 as discriminator.

Multiple values attached to a single constructor:

`type These a b = This(a) | That(b) | These(a,b)`

Thus `These Int16 Bool` becomes `(Int8, Int16)`, `(Int8, Bool)`, `(Int8, Int16, Bool)`