### PR TITLE
Fix drawing demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ run-build-malloc-11:
 	cabal run wasm-calc11 -- build wasm-calc11/static/malloc.calc > wasm-calc11/static/malloc.wasm
 	wasm2wat wasm-calc11/static/malloc.wasm > wasm-calc11/static/malloc-new.wat
 
+.PHONY: run-build-drawing-demo-11
+run-build-drawing-demo-11:
+	cabal run wasm-calc11 -- build wasm-calc11/demo/draw.calc > wasm-calc11/demo/draw.wasm
+
 # end of calcs
 
 # run with `make watch version=9` to run tests / ghci for wasm-calc9

--- a/flake.nix
+++ b/flake.nix
@@ -114,6 +114,9 @@
               pkgs.nodejs
               pkgs.watchexec
               pkgs.nodePackages_latest.serve
+
+              # wasm tooling
+              pkgs.wabt
             ];
 
             inputsFrom = builtins.attrValues self.packages.${system};

--- a/wasm-calc10/src/Calc/Wasm/FromExpr/Helpers.hs
+++ b/wasm-calc10/src/Calc/Wasm/FromExpr/Helpers.hs
@@ -154,12 +154,11 @@ getAbilitiesForFunction functionAbilities fnName =
 
 -- take only the function info we need
 getFunctionMap ::
-  Natural ->
   [Function (Type ann)] ->
   Either
     FromWasmError
     (M.Map FunctionName FromExprFunc)
-getFunctionMap offset mdFunctions =
+getFunctionMap mdFunctions =
   M.fromList
     <$> traverse
       ( \(i, Function {fnFunctionName, fnGenerics, fnArgs, fnBody}) -> do
@@ -176,7 +175,7 @@ getFunctionMap offset mdFunctions =
                 }
             )
       )
-      (zip [offset ..] mdFunctions)
+      (zip [0 ..] mdFunctions)
 
 -- take only the function info we need
 getImportMap ::

--- a/wasm-calc10/src/Calc/Wasm/FromExpr/Module.hs
+++ b/wasm-calc10/src/Calc/Wasm/FromExpr/Module.hs
@@ -180,7 +180,7 @@ fromModule ::
 fromModule wholeMod@(Module {mdMemory, mdTests, mdGlobals, mdImports, mdFunctions}) = do
   let moduleAbilities = getAbilitiesForModule wholeMod
   importMap <- getImportMap mdImports
-  funcMap <- getFunctionMap (fromIntegral (length importMap)) mdFunctions
+  funcMap <- getFunctionMap mdFunctions
   globalMap <- getGlobalMap mdGlobals
 
   wasmGlobals <- traverse fromGlobal mdGlobals

--- a/wasm-calc10/test/Test/Wasm/WasmSpec.hs
+++ b/wasm-calc10/test/Test/Wasm/WasmSpec.hs
@@ -51,6 +51,13 @@ spec = do
                 joinLines ["42n", "42n"]
               ),
               ( joinLines
+                  [ "import console.log as consoleLog(number: Int64) -> Void",
+                    "function max(one: Int64, two: Int64) -> Int64 { if one > two then one else two }",
+                    "export function test() -> Int64 { let a = max(0,25); let _ = consoleLog(a); let _ = consoleLog(a + 1); 100 }"
+                  ],
+                joinLines ["25n", "26n"]
+              ),
+              ( joinLines
                   [ "import env.memory as memory 1000",
                     "import console.log as consoleLog(number: Int64) -> Void",
                     "export function test() -> Int64 { let (a,b) = ((1: Int64), (2: Int64)); let _ = consoleLog(a + b); 100 }"

--- a/wasm-calc11/demo/.gitignore
+++ b/wasm-calc11/demo/.gitignore
@@ -1,0 +1,2 @@
+# ignore compiler wasm files
+*.wasm

--- a/wasm-calc11/demo/README.md
+++ b/wasm-calc11/demo/README.md
@@ -1,0 +1,12 @@
+# demo
+
+This is a small demo that runs in the browser, passing a `draw` function into a
+WASM module. 
+
+To open it in a browser, run `serve .` and navigate to
+`localhost:3000/draw.html`.
+
+To change the file and see results, run `watchexec -w ./**/*.calc make
+run-build-drawing-demo-7`. This will watch all `.calc` files and recompile on file changes.
+
+You will need to reload the browser after each change.

--- a/wasm-calc11/demo/draw.calc
+++ b/wasm-calc11/demo/draw.calc
@@ -1,0 +1,35 @@
+import imports.draw as draw(
+  x: Int64, y: Int64, r: Int64, g: Int64, b: Int64
+) -> Void
+
+function min(floor: Int64, value: Int64) -> Int64 { 
+  if value > floor then value else floor
+}
+
+function max(ceiling: Int64, value: Int64) -> Int64 { 
+  if value < ceiling then value else ceiling
+}
+
+function clamp(
+  floor: Int64, ceiling: Int64, value: Int64
+) -> Int64 { min(floor, max(ceiling, value))}
+
+function drawBounded(
+  x: Int64, y: Int64, r: Int64, g: Int64, b: Int64
+) -> Void { 
+  let maxWidth: Int64 = 400; 
+  let maxHeight: Int64 = 300; 
+  draw(
+    clamp(0, maxWidth, x), clamp(0, maxHeight, y), r, g, b
+  )
+}
+
+export function test(index: Int64) -> Void { 
+  let r = clamp(0, 255, index * 2); 
+  let g = clamp(0, 255, 255 - r); 
+  let b = clamp(0, 255, r * 3); 
+  drawBounded(index * 2, index * 3, r, g, b); 
+  drawBounded(100 - index, index * 3, b, g, r); 
+  drawBounded(10 + index * 3, 50 - index * 2, g, r, b); 
+  drawBounded(index * 4, 200 - index * 3, b, r, g)
+}

--- a/wasm-calc11/demo/draw.html
+++ b/wasm-calc11/demo/draw.html
@@ -1,0 +1,47 @@
+<!doctype html>
+
+<html>
+
+  <head>
+    <meta charset="utf-8">
+    <title>WASM test</title>
+  </head>
+
+  <body>
+    <script>
+      const drawDot = (x,y,r,g,b) => {
+        const canvas = document.getElementById("canvas");
+        if (canvas.getContext) {
+          const ctx = canvas.getContext("2d");
+          ctx.fillStyle = "rgb(" + r + "," + g + "," + b + ")"
+          ctx.fillRect(x, y, x + 1, y + 1);
+        }
+      }
+
+      const importObject = {
+        imports: {
+          draw: (bigX,bigY,bigR,bigG,bigB) => {
+            drawDot(Number(bigX), Number(bigY),Number(bigR),Number(bigG), Number(bigB))
+          }
+        }
+      };
+
+      fetch("draw.wasm").then(response =>
+        response.arrayBuffer()
+      ).then(bytes =>
+        WebAssembly.instantiate(bytes, importObject)
+      ).then(result => {
+        let i = 0;
+        const maximum = 150;
+        setInterval(() => {
+          const newI = i < maximum ? i + 1 : 0;
+          const bigI = BigInt(newI);
+          result.instance.exports.test(bigI);
+          i = newI
+        },1);
+      });
+    </script>
+    <canvas id="canvas" width=600 height=600/>
+  </body>
+
+</html>

--- a/wasm-calc11/src/Calc/Wasm/FromExpr/Drops.hs
+++ b/wasm-calc11/src/Calc/Wasm/FromExpr/Drops.hs
@@ -25,7 +25,7 @@ import Calc.Wasm.FromExpr.Patterns (Path (..))
 import Calc.Wasm.FromExpr.Types
 import Calc.Wasm.ToWasm.Helpers
 import Calc.Wasm.ToWasm.Types
-import Control.Monad (foldM )
+import Control.Monad (foldM)
 import Control.Monad.Except
 import Control.Monad.State
 import Data.Foldable (foldl')

--- a/wasm-calc11/src/Calc/Wasm/FromExpr/Drops.hs
+++ b/wasm-calc11/src/Calc/Wasm/FromExpr/Drops.hs
@@ -25,7 +25,7 @@ import Calc.Wasm.FromExpr.Patterns (Path (..))
 import Calc.Wasm.FromExpr.Types
 import Calc.Wasm.ToWasm.Helpers
 import Calc.Wasm.ToWasm.Types
-import Control.Monad (foldM, void)
+import Control.Monad (foldM )
 import Control.Monad.Except
 import Control.Monad.State
 import Data.Foldable (foldl')
@@ -34,7 +34,6 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
-import Debug.Trace
 import GHC.Natural
 
 -- | for a variable, describe how to get it
@@ -101,7 +100,6 @@ addDropsToWasmExpr drops wasmExpr =
   -- drop identifiers we will no longer need
   case drops of
     Just (DropIdentifiers idents) -> do
-      traceShowM (void <$> idents)
       nats <- traverse (\(ident, ty) -> (,) <$> lookupIdent ident <*> pure ty) idents
       foldM
         ( \restExpr (index, ty) -> do

--- a/wasm-calc11/src/Calc/Wasm/FromExpr/Helpers.hs
+++ b/wasm-calc11/src/Calc/Wasm/FromExpr/Helpers.hs
@@ -154,12 +154,11 @@ getAbilitiesForFunction functionAbilities fnName =
 
 -- take only the function info we need
 getFunctionMap ::
-  Natural ->
   [Function (Type ann)] ->
   Either
     FromWasmError
     (M.Map FunctionName FromExprFunc)
-getFunctionMap offset mdFunctions =
+getFunctionMap mdFunctions =
   M.fromList
     <$> traverse
       ( \(i, Function {fnFunctionName, fnGenerics, fnArgs, fnBody}) -> do
@@ -176,7 +175,7 @@ getFunctionMap offset mdFunctions =
                 }
             )
       )
-      (zip [offset ..] mdFunctions)
+      (zip [0 ..] mdFunctions)
 
 -- take only the function info we need
 getImportMap ::

--- a/wasm-calc11/src/Calc/Wasm/FromExpr/Module.hs
+++ b/wasm-calc11/src/Calc/Wasm/FromExpr/Module.hs
@@ -180,7 +180,7 @@ fromModule ::
 fromModule wholeMod@(Module {mdMemory, mdTests, mdGlobals, mdImports, mdFunctions}) = do
   let moduleAbilities = getAbilitiesForModule wholeMod
   importMap <- getImportMap mdImports
-  funcMap <- getFunctionMap (fromIntegral (length importMap)) mdFunctions
+  funcMap <- getFunctionMap mdFunctions
   globalMap <- getGlobalMap mdGlobals
 
   wasmGlobals <- traverse fromGlobal mdGlobals

--- a/wasm-calc11/src/Calc/Wasm/ToWasm/Types.hs
+++ b/wasm-calc11/src/Calc/Wasm/ToWasm/Types.hs
@@ -30,7 +30,7 @@ data ToWasmEnv = ToWasmEnv
     tweFunctionsOffset :: Natural,
     tweGeneratedFunctionOffset :: Natural
   }
-  deriving stock (Eq,Ord,Show)
+  deriving stock (Eq, Ord, Show)
 
 data WasmType
   = I8

--- a/wasm-calc11/src/Calc/Wasm/ToWasm/Types.hs
+++ b/wasm-calc11/src/Calc/Wasm/ToWasm/Types.hs
@@ -30,6 +30,7 @@ data ToWasmEnv = ToWasmEnv
     tweFunctionsOffset :: Natural,
     tweGeneratedFunctionOffset :: Natural
   }
+  deriving stock (Eq,Ord,Show)
 
 data WasmType
   = I8

--- a/wasm-calc11/test/Test/Wasm/WasmSpec.hs
+++ b/wasm-calc11/test/Test/Wasm/WasmSpec.hs
@@ -51,8 +51,7 @@ spec = do
                 joinLines ["42n", "42n"]
               ),
               ( joinLines
-                  [
-                    "import console.log as consoleLog(number: Int64) -> Void",
+                  [ "import console.log as consoleLog(number: Int64) -> Void",
                     "function max(one: Int64, two: Int64) -> Int64 { if one > two then one else two }",
                     "export function test() -> Int64 { let a = max(0,25); let _ = consoleLog(a); let _ = consoleLog(a + 1); 100 }"
                   ],

--- a/wasm-calc11/test/Test/Wasm/WasmSpec.hs
+++ b/wasm-calc11/test/Test/Wasm/WasmSpec.hs
@@ -51,6 +51,14 @@ spec = do
                 joinLines ["42n", "42n"]
               ),
               ( joinLines
+                  [
+                    "import console.log as consoleLog(number: Int64) -> Void",
+                    "function max(one: Int64, two: Int64) -> Int64 { if one > two then one else two }",
+                    "export function test() -> Int64 { let a = max(0,25); let _ = consoleLog(a); let _ = consoleLog(a + 1); 100 }"
+                  ],
+                joinLines ["25n", "26n"]
+              ),
+              ( joinLines
                   [ "import env.memory as memory 1000",
                     "import console.log as consoleLog(number: Int64) -> Void",
                     "export function test() -> Int64 { let (a,b) = ((1: Int64), (2: Int64)); let _ = consoleLog(a + b); 100 }"

--- a/wasm-calc8/test/Test/Wasm/WasmSpec.hs
+++ b/wasm-calc8/test/Test/Wasm/WasmSpec.hs
@@ -96,6 +96,13 @@ spec = do
                 joinLines ["42n", "42n"]
               ),
               ( joinLines
+                  [ "import console.log as consoleLog(number: Int64) -> Void",
+                    "function max(one: Int64, two: Int64) -> Int64 { if one > two then one else two }",
+                    "export function test() -> Int64 { let a = max(0,25); let _ = consoleLog(a); let _ = consoleLog(a + 1); 100 }"
+                  ],
+                joinLines ["25n", "26n"]
+              ),
+              ( joinLines
                   [ "import env.memory as memory 1000",
                     "import console.log as consoleLog(number: Int64) -> Void",
                     "export function test() -> Int64 { let (a,b) = ((1: Int64), (2: Int64)); let _ = consoleLog(a + b); 100 }"

--- a/wasm-calc9/src/Calc/Wasm/FromExpr/Helpers.hs
+++ b/wasm-calc9/src/Calc/Wasm/FromExpr/Helpers.hs
@@ -198,12 +198,11 @@ getAbilitiesForFunction functionAbilities fnName =
 
 -- take only the function info we need
 getFunctionMap ::
-  Natural ->
   [Function (Type ann)] ->
   Either
     FromWasmError
     (M.Map FunctionName FromExprFunc)
-getFunctionMap offset mdFunctions =
+getFunctionMap mdFunctions =
   M.fromList
     <$> traverse
       ( \(i, Function {fnFunctionName, fnGenerics, fnArgs, fnBody}) -> do
@@ -220,7 +219,7 @@ getFunctionMap offset mdFunctions =
                 }
             )
       )
-      (zip [offset ..] mdFunctions)
+      (zip [0 ..] mdFunctions)
 
 -- take only the function info we need
 getImportMap ::

--- a/wasm-calc9/src/Calc/Wasm/FromExpr/Module.hs
+++ b/wasm-calc9/src/Calc/Wasm/FromExpr/Module.hs
@@ -180,7 +180,7 @@ fromModule ::
 fromModule wholeMod@(Module {mdMemory, mdTests, mdGlobals, mdImports, mdFunctions}) = do
   let moduleAbilities = getAbilitiesForModule wholeMod
   importMap <- getImportMap mdImports
-  funcMap <- getFunctionMap (fromIntegral (length importMap)) mdFunctions
+  funcMap <- getFunctionMap mdFunctions
   globalMap <- getGlobalMap mdGlobals
 
   wasmGlobals <- traverse fromGlobal mdGlobals

--- a/wasm-calc9/test/Test/Wasm/WasmSpec.hs
+++ b/wasm-calc9/test/Test/Wasm/WasmSpec.hs
@@ -143,6 +143,13 @@ spec = do
                 joinLines ["42n", "42n"]
               ),
               ( joinLines
+                  [ "import console.log as consoleLog(number: Int64) -> Void",
+                    "function max(one: Int64, two: Int64) -> Int64 { if one > two then one else two }",
+                    "export function test() -> Int64 { let a = max(0,25); let _ = consoleLog(a); let _ = consoleLog(a + 1); 100 }"
+                  ],
+                joinLines ["25n", "26n"]
+              ),
+              ( joinLines
                   [ "import env.memory as memory 1000",
                     "import console.log as consoleLog(number: Int64) -> Void",
                     "export function test() -> Int64 { let (a,b) = ((1: Int64), (2: Int64)); let _ = consoleLog(a + b); 100 }"


### PR DESCRIPTION
The canvas demo in `wasm-calc8` doesn't build in later versions, turns out we were messing up function numbers when imports are involved by counting the imports twice.

Next we should see if the `wasm4` repo still builds with the newer versions.