### PR TITLE
Branching in linearity checking

### DIFF
--- a/wasm-calc11/src/Calc/Linearity/Error.hs
+++ b/wasm-calc11/src/Calc/Linearity/Error.hs
@@ -11,12 +11,12 @@ where
 import Calc.SourceSpan
 import Calc.Types.Annotation
 import Calc.Types.Identifier
+import qualified Data.List.NonEmpty as NE
 import Data.Maybe (catMaybes, mapMaybe)
 import qualified Data.Text as T
 import qualified Error.Diagnose as Diag
 import qualified Prettyprinter as PP
 import qualified Prettyprinter.Render.Text as PP
-import qualified Data.List.NonEmpty as NE
 
 data LinearityError ann
   = NotUsed ann Identifier

--- a/wasm-calc11/src/Calc/Linearity/Error.hs
+++ b/wasm-calc11/src/Calc/Linearity/Error.hs
@@ -16,10 +16,11 @@ import qualified Data.Text as T
 import qualified Error.Diagnose as Diag
 import qualified Prettyprinter as PP
 import qualified Prettyprinter.Render.Text as PP
+import qualified Data.List.NonEmpty as NE
 
 data LinearityError ann
   = NotUsed ann Identifier
-  | UsedMultipleTimes [ann] Identifier
+  | UsedMultipleTimes (NE.NonEmpty ann) Identifier
   deriving stock (Eq, Ord, Show)
 
 prettyPrint :: PP.Doc doc -> T.Text
@@ -83,7 +84,7 @@ linearityErrorDiagnostic input e =
                             )
                         )
                 )
-                anns
+                (NE.toList anns)
             )
             []
    in Diag.addReport diag report

--- a/wasm-calc11/src/Calc/Linearity/Types.hs
+++ b/wasm-calc11/src/Calc/Linearity/Types.hs
@@ -39,7 +39,8 @@ data UserDefined a = UserDefined a | Internal a
 
 data LinearState ann = LinearState
   { lsVars :: M.Map (UserDefined Identifier) (LinearityType, ann),
-    lsUses :: [(Identifier, Linearity ann)],
+    lsUses :: NE.NonEmpty [(Identifier, Linearity ann)],
     lsFresh :: Natural
   }
   deriving stock (Eq, Ord, Show, Functor)
+

--- a/wasm-calc11/src/Calc/Linearity/Types.hs
+++ b/wasm-calc11/src/Calc/Linearity/Types.hs
@@ -39,7 +39,7 @@ data UserDefined a = UserDefined a | Internal a
 
 data LinearState ann = LinearState
   { lsVars :: M.Map (UserDefined Identifier) (LinearityType, ann),
-    lsUses :: NE.NonEmpty [(Identifier, Linearity ann)],
+    lsUses :: NE.NonEmpty (M.Map Identifier (NE.NonEmpty (Linearity ann))),
     lsFresh :: Natural
   }
   deriving stock (Eq, Ord, Show, Functor)

--- a/wasm-calc11/src/Calc/Linearity/Types.hs
+++ b/wasm-calc11/src/Calc/Linearity/Types.hs
@@ -43,4 +43,3 @@ data LinearState ann = LinearState
     lsFresh :: Natural
   }
   deriving stock (Eq, Ord, Show, Functor)
-

--- a/wasm-calc11/src/Calc/Linearity/Validate.hs
+++ b/wasm-calc11/src/Calc/Linearity/Validate.hs
@@ -9,7 +9,6 @@ module Calc.Linearity.Validate
   )
 where
 
-import qualified Data.List.NonEmpty as NE
 import Calc.Linearity.Decorate
 import Calc.Linearity.Error
 import Calc.Linearity.Types
@@ -25,6 +24,7 @@ import Control.Monad.State
 import Control.Monad.Writer
 import Data.Foldable (traverse_)
 import Data.Functor (($>))
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
 
 getLinearityAnnotation :: Linearity ann -> ann
@@ -40,7 +40,7 @@ validateGlobal ::
   Global (Type ann) ->
   Either (LinearityError ann) (Expr (Type ann, Maybe (Drops ann)))
 validateGlobal glob = do
-  let  (expr, linearState) = getGlobalUses glob
+  let (expr, linearState) = getGlobalUses glob
   validate linearState $> expr
 
 validateFunction ::
@@ -66,9 +66,8 @@ validate (LinearState {lsVars, lsUses}) =
                   Nothing -> Left (NotUsed ann ident)
                   Just neUses ->
                     if length neUses == 1
-                       then Right ()
-                       else
-                          Left (UsedMultipleTimes (getLinearityAnnotation <$> neUses) ident)
+                      then Right ()
+                      else Left (UsedMultipleTimes (getLinearityAnnotation <$> neUses) ident)
    in traverse_ validateFunctionItem (M.toList lsVars)
 
 getFunctionUses ::
@@ -99,7 +98,7 @@ getFunctionUses (Function {fnBody, fnArgs}) =
 getGlobalUses ::
   (Show ann) =>
   Global (Type ann) ->
-    (Expr (Type ann, Maybe (Drops ann)), LinearState ann)
+  (Expr (Type ann, Maybe (Drops ann)), LinearState ann)
 getGlobalUses (Global {glbExpr}) =
   fst $ runIdentity $ runWriterT $ runStateT action initialState
   where

--- a/wasm-calc11/test/Test/Linearity/LinearitySpec.hs
+++ b/wasm-calc11/test/Test/Linearity/LinearitySpec.hs
@@ -241,28 +241,29 @@ spec = do
                 LinearState
                   { lsVars =
                       M.fromList [(UserDefined "a", (LTPrimitive, ())), (UserDefined "b", (LTPrimitive, ()))],
-                    lsUses = NE.singleton [("b", Whole ()), ("a", Whole ())],
+                    lsUses = NE.singleton (M.fromList [("b", NE.singleton $ Whole ()), ("a", NE.singleton $ Whole ())]),
                     lsFresh = 0
                   }
               ),
               ( "function pair<a,b>(a: a, b: b) -> (a,b) { (a,b) }",
                 LinearState
                   { lsVars = M.fromList [(UserDefined "a", (LTBoxed, ())), (UserDefined "b", (LTBoxed, ()))],
-                    lsUses = NE.singleton [("b", Whole ()), ("a", Whole ())],
+                    lsUses = NE.singleton (M.fromList [("b", NE.singleton $ Whole ()),
+                                      ("a", NE.singleton $ Whole ())]),
                     lsFresh = 0
                   }
               ),
               ( "function dontUseA<a,b>(a: a, b: b) -> b { b }",
                 LinearState
                   { lsVars = M.fromList [(UserDefined "a", (LTBoxed, ())), (UserDefined "b", (LTBoxed, ()))],
-                    lsUses = NE.singleton [("b", Whole ())],
+                    lsUses = NE.singleton (M.fromList [("b", NE.singleton $ Whole ())]),
                     lsFresh = 0
                   }
               ),
               ( "function dup<a>(a: a) -> (a,a) { (a,a)}",
                 LinearState
                   { lsVars = M.fromList [(UserDefined "a", (LTBoxed, ()))],
-                    lsUses = NE.singleton [("a", Whole ()), ("a", Whole ())],
+                    lsUses = NE.singleton (M.fromList [("a", NE.fromList [ Whole (),Whole () ])]),
                     lsFresh = 0
                   }
               )
@@ -280,7 +281,7 @@ spec = do
         strings
 
     describe "validateFunction" $ do
-      fdescribe "expected successes" $ do
+      describe "expected successes" $ do
         let success =
               [ "function sum (a: Int64, b: Int64) -> Int64 { a + b }",
                 "function pair<a,b>(a: a, b: b) -> (a,b) { (a,b) }",
@@ -302,7 +303,7 @@ spec = do
           )
           success
 
-      fdescribe "expected failures" $ do
+      describe "expected failures" $ do
         let failures =
               [ ( "function dontUseA<a,b>(a: a, b: b) -> b { b }",
                   NotUsed () "a"
@@ -311,13 +312,13 @@ spec = do
                   NotUsed () "a"
                 ),
                 ( "function dup<a>(a: a) -> (a,a) { (a,a)}",
-                  UsedMultipleTimes [(), ()] "a"
+                  UsedMultipleTimes (NE.fromList [(), ()]) "a"
                 ),
                 ( "function withPair<a,b>(pair: (a,b)) -> (a,a,b) { let (a,b) = pair; (a, a, b) }",
-                  UsedMultipleTimes [(), ()] "a"
+                  UsedMultipleTimes (NE.fromList [(), ()]) "a"
                 ),
                 ( "function bothSidesOfIf() -> (Boolean,Boolean) { let pair = (True,False); if True then { let _ = pair; pair } else pair }",
-                  UsedMultipleTimes [(), ()] "pair"
+                  UsedMultipleTimes (NE.fromList [(), ()]) "pair"
                 )
               ]
         traverse_

--- a/wasm-calc11/test/Test/Linearity/LinearitySpec.hs
+++ b/wasm-calc11/test/Test/Linearity/LinearitySpec.hs
@@ -248,8 +248,13 @@ spec = do
               ( "function pair<a,b>(a: a, b: b) -> (a,b) { (a,b) }",
                 LinearState
                   { lsVars = M.fromList [(UserDefined "a", (LTBoxed, ())), (UserDefined "b", (LTBoxed, ()))],
-                    lsUses = NE.singleton (M.fromList [("b", NE.singleton $ Whole ()),
-                                      ("a", NE.singleton $ Whole ())]),
+                    lsUses =
+                      NE.singleton
+                        ( M.fromList
+                            [ ("b", NE.singleton $ Whole ()),
+                              ("a", NE.singleton $ Whole ())
+                            ]
+                        ),
                     lsFresh = 0
                   }
               ),
@@ -263,7 +268,7 @@ spec = do
               ( "function dup<a>(a: a) -> (a,a) { (a,a)}",
                 LinearState
                   { lsVars = M.fromList [(UserDefined "a", (LTBoxed, ()))],
-                    lsUses = NE.singleton (M.fromList [("a", NE.fromList [ Whole (),Whole () ])]),
+                    lsUses = NE.singleton (M.fromList [("a", NE.fromList [Whole (), Whole ()])]),
                     lsFresh = 0
                   }
               )


### PR DESCRIPTION
Embarrassingly, we never checked whether the following was accepted by the linearity checker.

```haskell
let tuple = (True,False,False);
case True {
  True => { tuple },
  False => { tuple }
}
```

Previously we'd complain about multiple uses of `tuple`, but that's silly, now we scope our uses when navigating `if` and `case` statements.